### PR TITLE
Added ignored screens from code

### DIFF
--- a/src/main/java/zuve/searchablechests/ChestEventHandler.java
+++ b/src/main/java/zuve/searchablechests/ChestEventHandler.java
@@ -60,7 +60,8 @@ public class ChestEventHandler {
 		if (gui instanceof ContainerScreen && !(gui instanceof InventoryScreen)
 				&& ((ContainerScreen<?>) gui).getContainer().getInventory().size() >= 36
 						+ SearchableChestsConfig.minimumContainerSize
-				&& !SearchableChestsConfig.blacklist.contains(gui.getTitle().getString())) {
+				&& !SearchableChestsConfig.blacklist.contains(gui.getTitle().getString())
+				&& !SearchableChestsConfig.blacklistCode.contains(gui.getClass().getName())) {
 			mc.keyboardListener.enableRepeatEvents(true);
 			FontRenderer fontRenderer = mc.fontRenderer;
 			searchField = new TextFieldWidget(fontRenderer, 81, 6, 80, fontRenderer.FONT_HEIGHT, "");

--- a/src/main/java/zuve/searchablechests/SearchableChestsConfig.java
+++ b/src/main/java/zuve/searchablechests/SearchableChestsConfig.java
@@ -6,4 +6,5 @@ public class SearchableChestsConfig {
 	public static boolean autoFocus;
 	public static ArrayList<String> blacklist;
 	public static int minimumContainerSize;
+	public static ArrayList<String> blacklistCode = new ArrayList<String>();
 }


### PR DESCRIPTION
Simple code which can add support ignored screens from code. For authors mods who not want add buttons and not want support config.
Example: SearchableChestsConfig.blacklistCode.add("path.to.Screen");